### PR TITLE
Refactor the Segment class

### DIFF
--- a/examples/adsr_envelope_note/adsr_envelope_note.cc
+++ b/examples/adsr_envelope_note/adsr_envelope_note.cc
@@ -57,7 +57,7 @@ int main()
     double s_segment_duration = 4.0;
     double r_segment_duration = 3.0;
 
-    size_t number_of_steps;
+    size_t number_of_samples;
     uint32_t file_idx = 0;
     char file_name[200];
 
@@ -79,40 +79,40 @@ int main()
         file_idx++;
 
         // 2. Create the attack segment
-        number_of_steps = static_cast<size_t>(synthesiser.sampling_rate() * a_segment_duration);
+        number_of_samples = static_cast<size_t>(synthesiser.sampling_rate() * a_segment_duration);
         auto segment_attack =
             unique_ptr<Segment>(new ExponentialSegment(
                         start_amplitude_attack,
                         end_amplitude_attack,
                         exponent_a,
-                        number_of_steps));
+                        number_of_samples));
 
         // 3. Create the decay segment
-        number_of_steps = static_cast<size_t>(synthesiser.sampling_rate() * d_segment_duration);
+        number_of_samples = static_cast<size_t>(synthesiser.sampling_rate() * d_segment_duration);
         auto segment_decay =
             unique_ptr<Segment>(new ExponentialSegment(
                         start_amplitude_decay,
                         end_amplitude_decay,
                         exponent_d,
-                        number_of_steps));
+                        number_of_samples));
 
         // 3. Create the sustain segment
-        number_of_steps = static_cast<size_t>(synthesiser.sampling_rate() * s_segment_duration);
+        number_of_samples = static_cast<size_t>(synthesiser.sampling_rate() * s_segment_duration);
         auto segment_sustain =
             unique_ptr<Segment>(new ExponentialSegment(
                         start_amplitude_sustain,
                         end_amplitude_sustain,
                         exponent_s,
-                        number_of_steps));
+                        number_of_samples));
 
         // 4. Create the release segment
-        number_of_steps = static_cast<size_t>(synthesiser.sampling_rate() * r_segment_duration);
+        number_of_samples = static_cast<size_t>(synthesiser.sampling_rate() * r_segment_duration);
         auto segment_release =
             unique_ptr<Segment>(new ExponentialSegment(
                         start_amplitude_release,
                         end_amplitude_release,
                         exponent_r,
-                        number_of_steps));
+                        number_of_samples));
 
         // 5. Create the envelope
         AdsrEnvelope envelope(segment_attack, segment_decay, segment_sustain, segment_release);

--- a/include/envelope/segment.h
+++ b/include/envelope/segment.h
@@ -1,14 +1,14 @@
 //========================================================================
 //  FILE:
-//      include/common/segment.h 
+//      include/common/segment.h
 //
 //  AUTHOR:
-//      zimzum@github 
+//      zimzum@github
 //
 //  DESCRIPTION:
-//      Classes representing enevelop segments. 
+//      Classes representing enevelop segments.
 //
-//  License: GNU GPL v2.0 
+//  License: GNU GPL v2.0
 //========================================================================
 
 #ifndef SEGMENT_H
@@ -18,7 +18,7 @@
 
 
 //========================================================================
-// FORWARD DECLARATIONS 
+// FORWARD DECLARATIONS
 //========================================================================
 class ArEnvelope;
 class AdsrEnvelope;
@@ -27,7 +27,7 @@ class AdsrEnvelope;
 // PRIVATE DATA TYPES
 //========================================================================
 //------------------------------------------------------------------------
-//  NAME: 
+//  NAME:
 //      SegmentGradient
 //
 //  DESCRIPTION:
@@ -55,7 +55,7 @@ public:
     //--------------------------------------------------------------------
     // 1. CONSTRUCTORS/DESTRUCTOR/ASSIGNMENT OPERATORS
     //--------------------------------------------------------------------
-    explicit Segment();
+    explicit Segment(size_t number_of_samples_arg = 0);
     virtual ~Segment();
     explicit Segment(const Segment& rhs) = delete;
     explicit Segment(Segment&& rhs) = delete;
@@ -63,12 +63,12 @@ public:
     Segment& operator=(Segment&& rhs) = delete;
 
     //--------------------------------------------------------------------
-    // 2. GENERAL USER INTERFACE 
+    // 2. GENERAL USER INTERFACE
     //--------------------------------------------------------------------
     //--------------------------------------------------------------------
     //  NAME:
-    //      GetSegment()
-    //  
+    //      GetSamples()
+    //
     //  DESCRIPTION:
     //      Returns a copy of the segment in form of vector of float.
     //      Note that derived classes are not forced to internally store
@@ -79,39 +79,60 @@ public:
     //  OUTPUT:
     //      The segment
     //--------------------------------------------------------------------
-    virtual std::vector<float> GetSegment() = 0;
+    virtual std::vector<float> GetSamples() {
+      if (!generated_) GenerateSamples();
+
+      return samples_;
+    }
 
     //--------------------------------------------------------------------
     //  NAME:
-    //      operator[] 
-    //  
+    //      GenerateSamples()
+    //
+    //  DESCRIPTION:
+    //      Generates the samples for this segment. Note that every time the
+    //      parameters of a segment are changed, this method needs to be called
+    //      to regrenerate the samples.
+    //  INPUT:
+    //      None
+    //  OUTPUT:
+    //      None
+    //--------------------------------------------------------------------
+    virtual void GenerateSamples() = 0;
+
+    //--------------------------------------------------------------------
+    //  NAME:
+    //      operator[]
+    //
     //  DESCRIPTION:
     //      Return the n-th element in the segment.
     //  INPUT:
-    //      Index of the segment element to be returned. 
+    //      Index of the segment element to be returned.
     //  OUTPUT:
     //      The value of the segment at the specified position
     //--------------------------------------------------------------------
-    virtual const float& operator[](const std::size_t position) const = 0;
-    virtual float& operator[](const std::size_t position) = 0;
+    virtual const float& operator[](const std::size_t position) const;
+    virtual float& operator[](const std::size_t position);
 
     //--------------------------------------------------------------------
     //  NAME:
-    //      IsEmpty() 
-    //  
+    //      IsEmpty()
+    //
     //  DESCRIPTION:
     //      Check whether the segment is empty
     //  INPUT:
     //      None
     //  OUTPUT:
-    //      True if the segment is empty, false otherwise. 
+    //      True if the segment is empty, false otherwise.
     //--------------------------------------------------------------------
     virtual bool IsEmpty() const = 0;
 
+    bool IsGenerated() {return generated_;}
+
     //--------------------------------------------------------------------
     //  NAME:
-    //      Length() 
-    //  
+    //      GetLength()
+    //
     //  DESCRIPTION:
     //      Returns the length of this Segment expressed in samples.
     //  INPUT:
@@ -119,21 +140,26 @@ public:
     //  OUTPUT:
     //      The length of this Segment expressed in samples.
     //--------------------------------------------------------------------
-    virtual std::size_t Length() const = 0;
+    virtual std::size_t GetLength() const = 0;
 
     //--------------------------------------------------------------------
     // 3. ACCESSORS
     //--------------------------------------------------------------------
     // None
 
+protected:
+    std::vector<float> samples_;
+    bool generated_;
+    std::size_t number_of_samples_;
+
 private:
     //--------------------------------------------------------------------
-    // 4. PRIVATE METHODS 
+    // 4. PRIVATE METHODS
     //--------------------------------------------------------------------
     // None
 
     //--------------------------------------------------------------------
-    // 5. DATA MEMMBERS 
+    // 5. DATA MEMMBERS
     //--------------------------------------------------------------------
     // None
 };
@@ -156,50 +182,53 @@ public:
     //--------------------------------------------------------------------
     //  NAME:
     //      ConstantSegment()
-    //  
+    //
     //  DESCRIPTION:
     //      Constructor
     //  INPUT:
     //      amplitude_arg       - the value of the segment
-    //      number_of_steps_arg - the total number of steps/samples in this
-    //                            segment 
+    //      number_of_samples_arg - the total number of steps/samples in this
+    //                            segment
     //--------------------------------------------------------------------
     explicit ConstantSegment(
-            float amplitude_arg, 
-            size_t number_of_steps_arg);
+            float amplitude_arg = 0.0,
+            size_t number_of_samples_arg = 0);
     ~ConstantSegment();
 
     //--------------------------------------------------------------------
-    // 2. GENERAL USER INTERFACE 
+    // 2. GENERAL USER INTERFACE
     //--------------------------------------------------------------------
+    void SetAmplitude(float amp) {
+      amplitude_ = amp;
+      generated_ = false;
+    }
+
+    void SetNumberOfSamples(size_t n) {
+      number_of_samples_ = n;
+      generated_ = false;
+    }
+
     //--------------------------------------------------------------------
     // Virtual functions/operators
     //--------------------------------------------------------------------
-    std::vector<float> GetSegment() override;
-    const float& operator[](const std::size_t position) const override;
-    float& operator[](const std::size_t position) override;
+    virtual void GenerateSamples() override;
     bool IsEmpty() const override;
-    std::size_t Length() const override;
-
-    //--------------------------------------------------------------------
-    // 3. ACCESSORS
-    //--------------------------------------------------------------------
-    std::size_t number_of_steps() const;
+    std::size_t GetLength() const override;
 
 private:
     //--------------------------------------------------------------------
-    // 4. PRIVATE METHODS 
+    // 4. PRIVATE METHODS
     //--------------------------------------------------------------------
     // None
 
     //--------------------------------------------------------------------
-    // 5. DATA MEMMBERS 
+    // 5. DATA MEMMBERS
     //--------------------------------------------------------------------
-    std::size_t number_of_steps_;
     float amplitude_;
     friend AdsrEnvelope;
     friend ArEnvelope;
 };
+
 //========================================================================
 // CLASS: LinearSegment
 //
@@ -218,53 +247,59 @@ public:
     //--------------------------------------------------------------------
     //  NAME:
     //      LinearSegment()
-    //  
+    //
     //  DESCRIPTION:
     //      Constructor
     //  INPUT:
     //      peak_amplitude_arg  - the peak amplitude value (guaranteed to be
     //                            reached) which is either the first value
     //                            (kDecline) or the last value (kIncline)
-    //      number_of_steps_arg - the total number of steps/samples in this
+    //      number_of_samples_arg - the total number of steps/samples in this
     //                            segment (including the peak value and 0)
     //      seg_gradient_arg        - either kDecline or kIncline
     //--------------------------------------------------------------------
     explicit LinearSegment(
-            float peak_amplitude_arg, 
-            size_t number_of_steps_arg,
-            SegmentGradient seg_gradient_arg);
+            float peak_amplitude_arg = 0.0,
+            size_t number_of_samples_arg = 0,
+            SegmentGradient seg_gradient_arg = SegmentGradient::kDecline);
     ~LinearSegment();
 
     //--------------------------------------------------------------------
-    // 2. GENERAL USER INTERFACE 
+    // 2. GENERAL USER INTERFACE
     //--------------------------------------------------------------------
+    void SetPeakAmplitude(float amp) {
+      peak_amplitude_ = amp;
+      generated_ = false;
+    }
+
+    void SetNumberOfSamples(size_t n) {
+      number_of_samples_ = n;
+      generated_ = false;
+    }
+
+    void SetGradient(SegmentGradient grad) {
+      seg_gradient_ = grad;
+      generated_ = false;
+    }
+
     //--------------------------------------------------------------------
     // Virtual functions/operators
     //--------------------------------------------------------------------
-    std::vector<float> GetSegment() override;
-    const float& operator[](const std::size_t position) const override;
-    float& operator[](const std::size_t position) override;
+    virtual void GenerateSamples() override;
     bool IsEmpty() const override;
-    std::size_t Length() const override;
-
-    //--------------------------------------------------------------------
-    // 3. ACCESSORS
-    //--------------------------------------------------------------------
-    std::size_t number_of_steps() const;
+    std::size_t GetLength() const override;
 
 private:
     //--------------------------------------------------------------------
-    // 4. PRIVATE METHODS 
+    // 4. PRIVATE METHODS
     //--------------------------------------------------------------------
     // None
 
     //--------------------------------------------------------------------
-    // 5. DATA MEMMBERS 
+    // 5. DATA MEMMBERS
     //--------------------------------------------------------------------
-    std::size_t number_of_steps_;
     float peak_amplitude_;
     SegmentGradient seg_gradient_;
-    std::vector<float> segment_;
     friend ArEnvelope;
 };
 
@@ -285,75 +320,84 @@ public:
     //--------------------------------------------------------------------
     //  NAME:
     //      ExponentialSegment()
-    //  
+    //
     //  DESCRIPTION:
     //      Constructor
     //  INPUT:
     //      amplitude_start_arg - amplitude at the start of the segment
     //      amplitude_end_arg   - amplitude at the end of the segment
-    //      number_of_steps_arg - the total number of steps/samples in this
+    //      number_of_samples_arg - the total number of steps/samples in this
     //                            segment
     //--------------------------------------------------------------------
     explicit ExponentialSegment(
-            float amplitude_start_arg, 
-            float amplitude_end_arg, 
-            float exponent_arg, 
-            size_t number_of_steps_arg);
+            float amplitude_start_arg = 0.0,
+            float amplitude_end_arg = 0.0,
+            float exponent_arg = 0.0,
+            size_t number_of_samples_arg = 0);
     ~ExponentialSegment();
 
     //--------------------------------------------------------------------
-    // 2. GENERAL USER INTERFACE 
+    // 2. GENERAL USER INTERFACE
     //--------------------------------------------------------------------
+    void SetStartAmplitude(float amp) {
+      amplitude_start_ = amp;
+      generated_ = false;
+    }
+
+    void SetEndAmplitude(float amp) {
+      amplitude_end_ = amp;
+      generated_ = false;
+    }
+
+    void SetExponent(float exp) {
+      exponent_ = exp;
+      generated_ = false;
+    }
+
+    void SetNumberOfSamples(size_t n) {
+      number_of_samples_ = n;
+      generated_ = false;
+    }
+
     //--------------------------------------------------------------------
     // Virtual functions/operators
     //--------------------------------------------------------------------
-    std::vector<float> GetSegment() override;
-    const float& operator[](const std::size_t position) const override;
-    float& operator[](const std::size_t position) override;
+    virtual void GenerateSamples() override;
     bool IsEmpty() const override;
-    std::size_t Length() const override;
-
-    //--------------------------------------------------------------------
-    //  NAME:
-    //      number_of_steps() 
-    //  
-    //  DESCRIPTION:
-    //      Accessor
-    //  INPUT:
-    //      None
-    //  OUTPUT:
-    //      number_of_steps_ 
-    //--------------------------------------------------------------------
-    std::size_t number_of_steps() const;
+    std::size_t GetLength() const override;
 
     //--------------------------------------------------------------------
     // 3. ACCESSORS
     //--------------------------------------------------------------------
-    // None
+    float GetEndAmplitude() {
+      return amplitude_end_;
+    }
+
+    float GetStartAmplitude() {
+      return amplitude_start_;
+    }
 
 private:
     //--------------------------------------------------------------------
-    // 4. PRIVATE METHODS 
+    // 4. PRIVATE METHODS
     //--------------------------------------------------------------------
     // None
 
     //--------------------------------------------------------------------
-    // 5. DATA MEMMBERS 
+    // 5. DATA MEMMBERS
     //--------------------------------------------------------------------
-    std::size_t number_of_steps_;
-    float amplitude_start_; 
-    float amplitude_end_; 
-    float exponent_; 
-    std::vector<float> segment_;
+    float amplitude_start_;
+    float amplitude_end_;
+    float exponent_;
     friend AdsrEnvelope;
 };
 
 //========================================================================
-//  CLASS: SegmentInitialisationException 
+//  CLASS: SegmentInitialisationException
 //
 // DESCRIPTION:
 //  Exception thrown when the corresponding segment is not initialised
-//  correctly. This can be detected by checking init_ agains the 'emptiness' 
+//  correctly. This can be detected by checking init_ agains the 'emptiness'
 //  of the segment.
 //========================================================================
 class SegmentInitialisationException : public std::exception

--- a/src/envelope/envelope.cc
+++ b/src/envelope/envelope.cc
@@ -79,8 +79,8 @@ void ArEnvelope::ApplyEnvelope(std::vector<int16_t> &samples) const
     assert(!samples.empty());
 
     // 1. Apply attack
-    vector<float>::const_iterator it_seg = attack_segment_.segment_.begin();
-    vector<float>::const_iterator it_seg_end = attack_segment_.segment_.end();
+    vector<float>::const_iterator it_seg = attack_segment_.samples_.begin();
+    vector<float>::const_iterator it_seg_end = attack_segment_.samples_.end();
     vector<int16_t>::iterator it_data = samples.begin();
     vector<int16_t>::const_iterator it_data_end = samples.begin() 
         + static_cast<vector<int16_t>::difference_type>(attack_number_of_samples_);
@@ -92,8 +92,8 @@ void ArEnvelope::ApplyEnvelope(std::vector<int16_t> &samples) const
     }
 
     // 2. Apply decay
-    it_seg = decay_segment_.segment_.begin();
-    it_seg_end = decay_segment_.segment_.end();
+    it_seg = decay_segment_.samples_.begin();
+    it_seg_end = decay_segment_.samples_.end();
     it_data = samples.end()
         - static_cast<vector<int16_t>::difference_type>(decay_number_of_samples_);
     it_data_end = samples.end();
@@ -132,7 +132,7 @@ AdsrEnvelope::AdsrEnvelope(
     decay_segment_(std::move(decay_segment_arg)),
     sustain_segment_(std::move(sustain_segment_arg)),
     release_segment_(std::move(release_segment_arg)),
-    length_(attack_segment_->Length() + decay_segment_->Length() + sustain_segment_->Length() + release_segment_->Length())
+    length_(attack_segment_->GetLength() + decay_segment_->GetLength() + sustain_segment_->GetLength() + release_segment_->GetLength())
 {
 }
 
@@ -147,13 +147,13 @@ void AdsrEnvelope::ApplyEnvelope(std::vector<int16_t> &samples) const
     assert(!samples.empty());
 
     // 1. Apply attack
-    vector<float> attack_segment = attack_segment_->GetSegment();
+    vector<float> attack_segment = attack_segment_->GetSamples();
 
     vector<float>::const_iterator it_seg     = attack_segment.begin();
     vector<float>::const_iterator it_seg_end = attack_segment.end();
     vector<int16_t>::iterator it_data        = samples.begin();
     vector<int16_t>::iterator it_data_end    = samples.begin()
-        + static_cast<vector<int16_t>::difference_type>(attack_segment_->Length());
+        + static_cast<vector<int16_t>::difference_type>(attack_segment_->GetLength());
 
     for ( ; it_seg != it_seg_end && it_data != it_data_end; it_seg++, it_data++)
     {
@@ -161,11 +161,11 @@ void AdsrEnvelope::ApplyEnvelope(std::vector<int16_t> &samples) const
     }
 
     // 2. Apply decay
-    vector<float> decay_segment = decay_segment_->GetSegment();
+    vector<float> decay_segment = decay_segment_->GetSamples();
 
     it_data     = it_data_end;
     it_data_end = it_data
-        + static_cast<vector<int16_t>::difference_type>(decay_segment_->Length());
+        + static_cast<vector<int16_t>::difference_type>(decay_segment_->GetLength());
     it_seg     = decay_segment.begin();
     it_seg_end = decay_segment.end();
 
@@ -175,11 +175,11 @@ void AdsrEnvelope::ApplyEnvelope(std::vector<int16_t> &samples) const
     }
 
     // 3. Apply sustain
-    vector<float> sustain_segment = sustain_segment_->GetSegment();
+    vector<float> sustain_segment = sustain_segment_->GetSamples();
 
     it_data     = it_data_end;
     it_data_end = it_data
-        + static_cast<vector<int16_t>::difference_type>(sustain_segment_->Length());
+        + static_cast<vector<int16_t>::difference_type>(sustain_segment_->GetLength());
     it_seg     = sustain_segment.begin();
     it_seg_end = sustain_segment.end();
 
@@ -189,11 +189,11 @@ void AdsrEnvelope::ApplyEnvelope(std::vector<int16_t> &samples) const
     }
 
     // 4. Apply release
-    vector<float> release_segment = release_segment_->GetSegment();
+    vector<float> release_segment = release_segment_->GetSamples();
 
     it_data     = it_data_end;
     it_data_end = it_data
-        + static_cast<vector<int16_t>::difference_type>(release_segment_->Length());
+        + static_cast<vector<int16_t>::difference_type>(release_segment_->GetLength());
     it_seg     = release_segment.begin();
     it_seg_end = release_segment.end();
 

--- a/unit_tests/source/envelope.cc
+++ b/unit_tests/source/envelope.cc
@@ -515,7 +515,7 @@ TEST(AdsrEnvelopeGenerationTest, HandleDifferentSustainLevels)
     double adsr_segment_duration      = 1.0;
     float end_amplitude_sustain;
     float start_amplitude_release;
-    size_t number_of_steps;
+    size_t number_of_samples;
 
     // NOTE: Amplitudes are defined so that there are no discontinuities.
     //       All segments are identical length. The attack, decay and
@@ -531,7 +531,7 @@ TEST(AdsrEnvelopeGenerationTest, HandleDifferentSustainLevels)
 
     // Number of samples in every segment
     adsr_segment_duration = duration / 4.0;
-    number_of_steps = static_cast<size_t>(synthesiser.sampling_rate() * adsr_segment_duration);
+    number_of_samples = static_cast<size_t>(synthesiser.sampling_rate() * adsr_segment_duration);
 
     for (auto it : end_amplitude_decay)
     {
@@ -545,7 +545,7 @@ TEST(AdsrEnvelopeGenerationTest, HandleDifferentSustainLevels)
                         start_amplitude_attack,
                         end_amplitude_attack,
                         exponent_adr,
-                        number_of_steps));
+                        number_of_samples));
 
         // 3. Create the decay segment
         auto segment_decay =
@@ -553,7 +553,7 @@ TEST(AdsrEnvelopeGenerationTest, HandleDifferentSustainLevels)
                         start_amplitude_decay,
                         it,
                         exponent_adr,
-                        number_of_steps));
+                        number_of_samples));
 
         // 3. Create the sustain segment
         auto segment_sustain =
@@ -561,7 +561,7 @@ TEST(AdsrEnvelopeGenerationTest, HandleDifferentSustainLevels)
                         start_amplitude_sustain,
                         it,
                         exponent_s,
-                        number_of_steps));
+                        number_of_samples));
 
         // 4. Create the release segment
         auto segment_release =
@@ -569,7 +569,7 @@ TEST(AdsrEnvelopeGenerationTest, HandleDifferentSustainLevels)
                         start_amplitude_release,
                         end_amplitude_release,
                         exponent_adr,
-                        number_of_steps));
+                        number_of_samples));
 
         // 5. Create the envelope
         AdsrEnvelope envelope(segment_attack, segment_decay, segment_sustain, segment_release);


### PR DESCRIPTION
This commit aims at simplifying the Segment class. Here are the major changes:
  - instead of referring to steps, samples in a segment are referred to
  as samples (i.e. certain variables and methods were renamed);
  - every segment allows it's parameters (e.g. length, amplitude) to be modified
  during the lifetime of the underlying object;
  - the user of the class is responsible for regeneration of the samples
  whenever the parameters of the segment are updated;
  - one segment class can be used for generating samples for various
  configurations (instead of creating a new object when, for example,
  updating the amplitude);
The segment family of classes still assumes that the Constant, Linear
and Exponential segments are separate Classes (inheriting from the
same base class). However, now there's more code sharing withing this
hierarchy.

The changes above enabled refactoring of the tests, so that more code
can be re-used between the classes. In particular, I've introduced test
fixtures (GTest nomenclature), so that the code is cleaner.